### PR TITLE
mysql: Allow aggregating table_io_waits query results

### DIFF
--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -12,7 +12,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"github.com/influxdata/telegraf/plugins/inputs/mysql/v1"
+	v1 "github.com/influxdata/telegraf/plugins/inputs/mysql/v1"
 
 	"github.com/go-sql-driver/mysql"
 )
@@ -22,6 +22,7 @@ type Mysql struct {
 	PerfEventsStatementsDigestTextLimit int64    `toml:"perf_events_statements_digest_text_limit"`
 	PerfEventsStatementsLimit           int64    `toml:"perf_events_statements_limit"`
 	PerfEventsStatementsTimeLimit       int64    `toml:"perf_events_statements_time_limit"`
+	AggregateTableIOWaits               bool     `toml:"aggregate_table_io_waits"`
 	TableSchemaDatabases                []string `toml:"table_schema_databases"`
 	GatherProcessList                   bool     `toml:"gather_process_list"`
 	GatherUserStatistics                bool     `toml:"gather_user_statistics"`
@@ -202,10 +203,10 @@ var (
 		"deleting":                  uint32(0),
 		"executing":                 uint32(0),
 		"execution of init_command": uint32(0),
-		"end":                     uint32(0),
-		"freeing items":           uint32(0),
-		"flushing tables":         uint32(0),
-		"fulltext initialization": uint32(0),
+		"end":                       uint32(0),
+		"freeing items":             uint32(0),
+		"flushing tables":           uint32(0),
+		"fulltext initialization":   uint32(0),
 		"idle":                      uint32(0),
 		"init":                      uint32(0),
 		"killed":                    uint32(0),
@@ -241,8 +242,8 @@ var (
 	}
 	// plaintext statuses
 	stateStatusMappings = map[string]string{
-		"user sleep":                               "idle",
-		"creating index":                           "altering table",
+		"user sleep":     "idle",
+		"creating index": "altering table",
 		"committing alter table to storage engine": "altering table",
 		"discard or import tablespace":             "altering table",
 		"rename":                                   "altering table",
@@ -306,14 +307,30 @@ const (
         SUM_TIMER_FETCH, SUM_TIMER_INSERT, SUM_TIMER_UPDATE, SUM_TIMER_DELETE
         FROM performance_schema.table_io_waits_summary_by_table
         WHERE OBJECT_SCHEMA NOT IN ('mysql', 'performance_schema')
-    `
+	`
+	perfTableIOWaitsAggregateQuery = `
+        SELECT
+            OBJECT_SCHEMA,
+            OBJECT_SCHEMA AS OBJECT_NAME,
+            SUM(COUNT_FETCH) AS COUNT_FETCH,
+            SUM(COUNT_INSERT) AS COUNT_INSERT,
+            SUM(COUNT_UPDATE) AS COUNT_UPDATE,
+            SUM(COUNT_DELETE) AS COUNT_DELETE,
+            SUM(SUM_TIMER_FETCH) AS SUM_TIMER_FETCH,
+            SUM(SUM_TIMER_INSERT) AS SUM_TIMER_INSERT,
+            SUM(SUM_TIMER_UPDATE) AS SUM_TIMER_UPDATE,
+            SUM(SUM_TIMER_DELETE) AS SUM_TIMER_DELETE
+        FROM performance_schema.table_io_waits_summary_by_table
+        WHERE OBJECT_SCHEMA NOT IN ('mysql', 'performance_schema')
+        GROUP BY OBJECT_SCHEMA
+	`
 	perfIndexIOWaitsQuery = `
         SELECT OBJECT_SCHEMA, OBJECT_NAME, ifnull(INDEX_NAME, 'NONE') as INDEX_NAME,
         COUNT_FETCH, COUNT_INSERT, COUNT_UPDATE, COUNT_DELETE,
         SUM_TIMER_FETCH, SUM_TIMER_INSERT, SUM_TIMER_UPDATE, SUM_TIMER_DELETE
         FROM performance_schema.table_io_waits_summary_by_index_usage
         WHERE OBJECT_SCHEMA NOT IN ('mysql', 'performance_schema')
-    `
+	`
 	perfTableLockWaitsQuery = `
         SELECT
             OBJECT_SCHEMA,
@@ -1028,7 +1045,11 @@ func getColSlice(l int) ([]interface{}, error) {
 // gatherPerfTableIOWaits can be used to get total count and time
 // of I/O wait event for each table and process
 func (m *Mysql) gatherPerfTableIOWaits(db *sql.DB, serv string, acc telegraf.Accumulator) error {
-	rows, err := db.Query(perfTableIOWaitsQuery)
+	queryStr := perfTableIOWaitsQuery
+	if m.AggregateTableIOWaits {
+		queryStr = perfTableIOWaitsAggregateQuery
+	}
+	rows, err := db.Query(queryStr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In some cases the results for individual tables are not interesting so
allow aggregating on database level to avoid large result sets.
