### PR TITLE
No colons in prometheus metric names

### DIFF
--- a/plugins/outputs/prometheus_client/v1/collector.go
+++ b/plugins/outputs/prometheus_client/v1/collector.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	invalidNameCharRE = regexp.MustCompile(`[^a-zA-Z0-9_:]`)
+	invalidNameCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 	validNameCharRE   = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*`)
 )
 

--- a/plugins/serializers/prometheus/convert.go
+++ b/plugins/serializers/prometheus/convert.go
@@ -25,7 +25,7 @@ var MetricNameTable = Table{
 	},
 	Rest: &unicode.RangeTable{
 		R16: []unicode.Range16{
-			{0x0030, 0x003A, 1}, // 0-:
+			{0x0030, 0x0039, 1}, // 0-9
 			{0x0041, 0x005A, 1}, // A-Z
 			{0x005F, 0x005F, 1}, // _
 			{0x0061, 0x007A, 1}, // a-z

--- a/plugins/serializers/prometheus/prometheus_test.go
+++ b/plugins/serializers/prometheus/prometheus_test.go
@@ -424,9 +424,9 @@ cpu_time_idle 43
 				),
 			},
 			expected: []byte(`
-# HELP cpu::xyzzy_time_idle Telegraf collected metric
-# TYPE cpu::xyzzy_time_idle untyped
-cpu::xyzzy_time_idle 42
+# HELP cpu__xyzzy_time_idle Telegraf collected metric
+# TYPE cpu__xyzzy_time_idle untyped
+cpu__xyzzy_time_idle 42
 `),
 		},
 		{
@@ -442,9 +442,9 @@ cpu::xyzzy_time_idle 42
 				),
 			},
 			expected: []byte(`
-# HELP cpu_time:idle Telegraf collected metric
-# TYPE cpu_time:idle untyped
-cpu_time:idle 42
+# HELP cpu_time_idle Telegraf collected metric
+# TYPE cpu_time_idle untyped
+cpu_time_idle 42
 `),
 		},
 		{


### PR DESCRIPTION
No colons allowed in Prometheus metric names and will be replaced with `_`