### PR TITLE
procstat: fix systemctl parsing for latest systemd

### DIFF
--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -379,6 +379,7 @@ func (p *Procstat) systemdUnitPIDs(units []string) ([][]PID, []map[string]string
 	}
 LINES:
 	for _, line := range bytes.Split(out, []byte{'\n'}) {
+		line := bytes.TrimRight(line, "\t ")
 		for _, unit := range units {
 			// Lines with unit name look like " ├─foo.service" or "  └─bar.service"
 			unitWithSuffix := unit

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -79,6 +79,8 @@ func TestMockExecCommand(t *testing.T) {
            │ ├─TestGather_systemdUnitPIDs.service
            │ │ └─11408 /usr/bin/foo
            │ │ └─11420 /usr/bin/bar
+           │ ├─TestTrailingSpaces_systemdUnitPIDs.service 	
+           │ │ └─11428 /usr/bin/foo
            │ ├─chronyd.service
            │ │ └─1931 /usr/sbin/chronyd
            └─machine.slice
@@ -401,6 +403,17 @@ func TestGather_systemdUnitPIDs(t *testing.T) {
 	assert.Equal(t, "TestGather_systemdUnitPIDs", tagsArray[0]["systemd_unit"])
 	assert.Equal(t, []PID{2371}, pidsArray[1])
 	assert.Equal(t, "foo.service", tagsArray[1]["systemd_unit"])
+}
+
+func TestTrailingSpaces_systemdUnitPIDs(t *testing.T) {
+	p := Procstat{
+		createPIDFinder: pidFinder([]PID{}, nil),
+		SystemdUnit:     "TestTrailingSpaces_systemdUnitPIDs",
+	}
+	pidsArray, tagsArray, err := p.findPids()
+	require.NoError(t, err)
+	assert.Equal(t, []PID{11428}, pidsArray[0])
+	assert.Equal(t, "TestTrailingSpaces_systemdUnitPIDs", tagsArray[0]["systemd_unit"])
 }
 
 func TestGather_cgroupPIDs(t *testing.T) {


### PR DESCRIPTION
Fix `systemctl` status output for the latest `systemd`, which adds sometimes whitespaces at the end of the line