### PR TITLE
feat(inputs.file): ignore stale metrics

### DIFF
--- a/AIVEN_CHANGES.md
+++ b/AIVEN_CHANGES.md
@@ -13,6 +13,10 @@
 * the way that telegraf provides ( globbing ) does not fit our systemd unit structure
 * we need to check units inside of containers
 
+### File
+
+* ignore stale metrics from file with a configurable grace period
+
 ### MySQL
 
 * added aggregated IOPerf Stats ( probably upstreamable )

--- a/plugins/inputs/file/README.md
+++ b/plugins/inputs/file/README.md
@@ -45,6 +45,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## significantly. Read more about cardinality here:
   ## https://docs.influxdata.com/influxdb/cloud/reference/glossary/#series-cardinality
   # file_tag = ""
+   
+
+  ## Discard metrics that have gone stale because the file was not refreshed
+  # grace_period = "1h"
 ```
 
 ## Metrics

--- a/plugins/inputs/file/dev/testfiles/stale.influx
+++ b/plugins/inputs/file/dev/testfiles/stale.influx
@@ -1,0 +1,1 @@
+test.metric,foo=bar baz=1i 1681892912251106048

--- a/plugins/inputs/file/sample.conf
+++ b/plugins/inputs/file/sample.conf
@@ -25,3 +25,7 @@
   ## significantly. Read more about cardinality here:
   ## https://docs.influxdata.com/influxdb/cloud/reference/glossary/#series-cardinality
   # file_tag = ""
+   
+
+  ## Discard metrics that have gone stale because the file was not refreshed
+  # grace_period = "1h"


### PR DESCRIPTION
Ignore stale metrics form files that were not updated because of external problems.