### PR TITLE
feat(inputs.clickhouse): Add replication queue metrics

### DIFF
--- a/AIVEN_CHANGES.md
+++ b/AIVEN_CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Input Plugins
 
+### ClickHouse
+
+* Add extra metrics to monitor the replication queue
+
 ### Elasticsearch
 
 * add cross cluster replication metrics ( they dont work for elasticsearch but its a first step until we have an opensearch plugin )
@@ -33,4 +37,3 @@
 ### Prometheus and Prometheus Remote Write
 
 * changes to make `Plugins.Prometheus Client` work for the same reasons as stated there
-

--- a/plugins/inputs/clickhouse/README.md
+++ b/plugins/inputs/clickhouse/README.md
@@ -133,7 +133,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     - cluster (Name of the cluster [optional])
     - shard_num (Shard number in the cluster [optional])
   - fields:
-    - too_many_tries_replicas (count of replicas which have `num_tries > 1`)
+    - num_total (Number of replication queue items)
+    - num_get_part (Number of GET_PART replication queue items)
+    - num_attach_part (Number of ATTACH_PART replication queue items)
+    - num_merge_parts (Number of regular MERGE_PARTS replication queue items)
+    - num_merge_parts_ttl_delete (Number of TTLDelete MERGE_PARTS replication queue items)
+    - num_merge_parts_ttl_recompress (Number of TTLRecompress MERGE_PARTS replication queue items)
+    - num_mutate_part (Number of MUTATE_PART replication queue items)
+    - too_many_tries_replicas (Number of replication queue items with num_tries > 100)
+    - num_tries_replicas (Number of replication queue items with num_tries > 1)
 
 - clickhouse_detached_parts (see [system.detached_parts][] for details)
   - tags:

--- a/plugins/inputs/clickhouse/clickhouse_test.go
+++ b/plugins/inputs/clickhouse/clickhouse_test.go
@@ -162,12 +162,26 @@ func TestGather(t *testing.T) {
 			case strings.Contains(query, "replication_too_many_tries_replicas"):
 				err := enc.Encode(result{
 					Data: []struct {
-						TooManyTriesReplicas chUInt64 `json:"replication_too_many_tries_replicas"`
-						NumTriesReplicas     chUInt64 `json:"replication_num_tries_replicas"`
+						NumTotal                   chUInt64 `json:"replication_num_total"`
+						NumGetPart                 chUInt64 `json:"replication_num_get_part"`
+						NumAttachPart              chUInt64 `json:"replication_num_attach_part"`
+						NumMergeParts              chUInt64 `json:"replication_num_merge_parts"`
+						NumMergePartsTtlDelete     chUInt64 `json:"replication_num_merge_parts_ttl_delete"`
+						NumMergePartsTtlRecompress chUInt64 `json:"replication_num_merge_parts_ttl_recompress"`
+						NumMutatePart              chUInt64 `json:"replication_num_mutate_part"`
+						TooManyTriesReplicas       chUInt64 `json:"replication_too_many_tries_replicas"`
+						NumTriesReplicas           chUInt64 `json:"replication_num_tries_replicas"`
 					}{
 						{
-							TooManyTriesReplicas: 10,
-							NumTriesReplicas:     100,
+							NumTotal:                   1000,
+							NumGetPart:                 20,
+							NumAttachPart:              30,
+							NumMergeParts:              40,
+							NumMergePartsTtlDelete:     50,
+							NumMergePartsTtlRecompress: 60,
+							NumMutatePart:              70,
+							TooManyTriesReplicas:       10,
+							NumTriesReplicas:           100,
 						},
 					},
 				})
@@ -348,8 +362,15 @@ func TestGather(t *testing.T) {
 	)
 	acc.AssertContainsFields(t, "clickhouse_replication_queue",
 		map[string]interface{}{
-			"too_many_tries_replicas": uint64(10),
-			"num_tries_replicas":      uint64(100),
+			"num_total":                      uint64(1000),
+			"num_get_part":                   uint64(20),
+			"num_attach_part":                uint64(30),
+			"num_merge_parts":                uint64(40),
+			"num_merge_parts_ttl_delete":     uint64(50),
+			"num_merge_parts_ttl_recompress": uint64(60),
+			"num_mutate_part":                uint64(70),
+			"too_many_tries_replicas":        uint64(10),
+			"num_tries_replicas":             uint64(100),
 		},
 	)
 	acc.AssertContainsFields(t, "clickhouse_detached_parts",


### PR DESCRIPTION
The extra metrics give a better view of what is happening in the cluster.

The description of the `too_many_tries_replicas` metrics was not accurate, this is fixed.
Ideally the name should be changed too, but that would break compatibility.

resolves [DDB-713]

# Required for all PRs

- [X] make lint
- [X] make check
- [X] make check-deps
- [X] make test
- [X] make docs
- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)


[DDB-713]: https://aiven.atlassian.net/browse/DDB-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ