### PR TITLE
aiven-procstat: fix swap metric

### DIFF
--- a/plugins/inputs/aiven-procstat/os_linux.go
+++ b/plugins/inputs/aiven-procstat/os_linux.go
@@ -1,0 +1,10 @@
+//go:build linux
+
+package aiven_procstat
+
+func addSwapToMemStats(proc Process, prefix string, fields map[string]interface{}) {
+	memMaps, err := proc.MemoryMaps(true)
+	if err == nil && memMaps != nil && len(*memMaps) > 0 {
+		fields[prefix+"memory_swap"] = (*memMaps)[0].Swap
+	}
+}

--- a/plugins/inputs/aiven-procstat/os_notlinux.go
+++ b/plugins/inputs/aiven-procstat/os_notlinux.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package aiven_procstat
+
+func addSwapToMemStats(Process, string, map[string]interface{}) {}

--- a/plugins/inputs/aiven-procstat/process.go
+++ b/plugins/inputs/aiven-procstat/process.go
@@ -15,6 +15,7 @@ type Process interface {
 	PageFaults() (*process.PageFaultsStat, error)
 	IOCounters() (*process.IOCountersStat, error)
 	MemoryInfo() (*process.MemoryInfoStat, error)
+	MemoryMaps(bool) (*[]process.MemoryMapsStat, error)
 	Name() (string, error)
 	Cmdline() (string, error)
 	NumCtxSwitches() (*process.NumCtxSwitchesStat, error)

--- a/plugins/inputs/aiven-procstat/procstat.go
+++ b/plugins/inputs/aiven-procstat/procstat.go
@@ -221,11 +221,11 @@ func (p *Procstat) addMetrics(proc Process, acc telegraf.Accumulator) {
 	if err == nil {
 		fields[prefix+"memory_rss"] = mem.RSS
 		fields[prefix+"memory_vms"] = mem.VMS
-		fields[prefix+"memory_swap"] = mem.Swap
 		fields[prefix+"memory_data"] = mem.Data
 		fields[prefix+"memory_stack"] = mem.Stack
 		fields[prefix+"memory_locked"] = mem.Locked
 	}
+	addSwapToMemStats(proc, prefix, fields)
 
 	mem_perc, err := proc.MemoryPercent()
 	if err == nil {

--- a/plugins/inputs/aiven-procstat/procstat_test.go
+++ b/plugins/inputs/aiven-procstat/procstat_test.go
@@ -79,7 +79,7 @@ func TestMockExecCommand(t *testing.T) {
            │ ├─TestGather_systemdUnitPIDs.service
            │ │ └─11408 /usr/bin/foo
            │ │ └─11420 /usr/bin/bar
-           │ ├─TestTrailingSpaces_systemdUnitPIDs.service 	
+           │ ├─TestTrailingSpaces_systemdUnitPIDs.service
            │ │ └─11428 /usr/bin/foo
            │ ├─chronyd.service
            │ │ └─1931 /usr/sbin/chronyd
@@ -203,6 +203,10 @@ func (p *testProc) Times() (*cpu.TimesStat, error) {
 
 func (p *testProc) RlimitUsage(gatherUsage bool) ([]process.RlimitStat, error) {
 	return []process.RlimitStat{}, nil
+}
+
+func (p *testProc) MemoryMaps(grouped bool) (*[]process.MemoryMapsStat, error) {
+	return &[]process.MemoryMapsStat{}, nil
 }
 
 var pid PID = PID(42)


### PR DESCRIPTION
Currently the swap metric for every process for every service is 0. This is because MemoryInfo() returns no Swap information on Linux. Instead, we should use MemoryMaps (grouped) for Swap data.
