### PR TITLE
fix(inputs.zookeeper): Parse mntr metrics with special characters in keys

### DIFF
--- a/plugins/inputs/aiven-procstat/os_linux.go
+++ b/plugins/inputs/aiven-procstat/os_linux.go
@@ -1,0 +1,10 @@
+//go:build linux
+
+package aiven_procstat
+
+func addSwapToMemStats(proc Process, prefix string, fields map[string]interface{}) {
+	memMaps, err := proc.MemoryMaps(true)
+	if err == nil && memMaps != nil && len(*memMaps) > 0 {
+		fields[prefix+"memory_swap"] = (*memMaps)[0].Swap
+	}
+}

--- a/plugins/inputs/aiven-procstat/os_notlinux.go
+++ b/plugins/inputs/aiven-procstat/os_notlinux.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package aiven_procstat
+
+func addSwapToMemStats(Process, string, map[string]interface{}) {}

--- a/plugins/inputs/aiven-procstat/process.go
+++ b/plugins/inputs/aiven-procstat/process.go
@@ -15,6 +15,7 @@ type Process interface {
 	PageFaults() (*process.PageFaultsStat, error)
 	IOCounters() (*process.IOCountersStat, error)
 	MemoryInfo() (*process.MemoryInfoStat, error)
+	MemoryMaps(bool) (*[]process.MemoryMapsStat, error)
 	Name() (string, error)
 	Cmdline() (string, error)
 	NumCtxSwitches() (*process.NumCtxSwitchesStat, error)

--- a/plugins/inputs/aiven-procstat/procstat.go
+++ b/plugins/inputs/aiven-procstat/procstat.go
@@ -221,11 +221,11 @@ func (p *Procstat) addMetrics(proc Process, acc telegraf.Accumulator) {
 	if err == nil {
 		fields[prefix+"memory_rss"] = mem.RSS
 		fields[prefix+"memory_vms"] = mem.VMS
-		fields[prefix+"memory_swap"] = mem.Swap
 		fields[prefix+"memory_data"] = mem.Data
 		fields[prefix+"memory_stack"] = mem.Stack
 		fields[prefix+"memory_locked"] = mem.Locked
 	}
+	addSwapToMemStats(proc, prefix, fields)
 
 	mem_perc, err := proc.MemoryPercent()
 	if err == nil {

--- a/plugins/inputs/aiven-procstat/procstat_test.go
+++ b/plugins/inputs/aiven-procstat/procstat_test.go
@@ -79,7 +79,7 @@ func TestMockExecCommand(t *testing.T) {
            │ ├─TestGather_systemdUnitPIDs.service
            │ │ └─11408 /usr/bin/foo
            │ │ └─11420 /usr/bin/bar
-           │ ├─TestTrailingSpaces_systemdUnitPIDs.service 	
+           │ ├─TestTrailingSpaces_systemdUnitPIDs.service
            │ │ └─11428 /usr/bin/foo
            │ ├─chronyd.service
            │ │ └─1931 /usr/sbin/chronyd
@@ -203,6 +203,10 @@ func (p *testProc) Times() (*cpu.TimesStat, error) {
 
 func (p *testProc) RlimitUsage(gatherUsage bool) ([]process.RlimitStat, error) {
 	return []process.RlimitStat{}, nil
+}
+
+func (p *testProc) MemoryMaps(grouped bool) (*[]process.MemoryMapsStat, error) {
+	return &[]process.MemoryMapsStat{}, nil
 }
 
 var pid PID = PID(42)

--- a/plugins/inputs/zookeeper/zookeeper.go
+++ b/plugins/inputs/zookeeper/zookeeper.go
@@ -8,8 +8,8 @@ import (
 	"crypto/tls"
 	_ "embed"
 	"fmt"
+	"io"
 	"net"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -23,12 +23,11 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-var zookeeperFormatRE = regexp.MustCompile(`^zk_(\w[\w\.\-]*)\s+([\w\.\-]+)`)
-
 type Zookeeper struct {
 	Servers     []string        `toml:"servers"`
 	Timeout     config.Duration `toml:"timeout"`
 	ParseFloats string          `toml:"parse_floats"`
+	Log         telegraf.Logger `toml:"-"`
 
 	EnableTLS bool `toml:"enable_tls" deprecated:"1.37.0;1.40.0;use 'tls_enable' instead"`
 	common_tls.ClientConfig
@@ -70,7 +69,6 @@ func (z *Zookeeper) Gather(acc telegraf.Accumulator) error {
 }
 
 func (z *Zookeeper) gatherServer(ctx context.Context, address string, acc telegraf.Accumulator) error {
-	var zookeeperState string
 	_, _, err := net.SplitHostPort(address)
 	if err != nil {
 		address = address + ":2181"
@@ -93,50 +91,13 @@ func (z *Zookeeper) gatherServer(ctx context.Context, address string, acc telegr
 	if _, err := fmt.Fprintf(c, "%s\n", "mntr"); err != nil {
 		return err
 	}
-	rdr := bufio.NewReader(c)
-	scanner := bufio.NewScanner(rdr)
 
 	service := strings.Split(address, ":")
 	if len(service) != 2 {
 		return fmt.Errorf("invalid service address: %s", address)
 	}
 
-	fields := make(map[string]interface{})
-	for scanner.Scan() {
-		line := scanner.Text()
-		parts := zookeeperFormatRE.FindStringSubmatch(line)
-
-		if len(parts) != 3 {
-			return fmt.Errorf("unexpected line in mntr response: %q", line)
-		}
-
-		measurement := strings.TrimPrefix(parts[1], "zk_")
-		if measurement == "server_state" {
-			zookeeperState = parts[2]
-			continue
-		}
-
-		sValue := parts[2]
-
-		// First attempt to parse as an int
-		iVal, err := strconv.ParseInt(sValue, 10, 64)
-		if err == nil {
-			fields[measurement] = iVal
-			continue
-		}
-
-		// If set, attempt to parse as a float
-		if z.ParseFloats == "float" {
-			fVal, err := strconv.ParseFloat(sValue, 64)
-			if err == nil {
-				fields[measurement] = fVal
-				continue
-			}
-		}
-
-		// Finally, save as a string
-		fields[measurement] = sValue
-	}
+	fields, zookeeperState := z.parseMntr(c)
 
 	srv := "localhost"
 	if service[0] != "" {
@@ -151,6 +112,58 @@ func (z *Zookeeper) gatherServer(ctx context.Context, address string, acc telegr
 	acc.AddFields("zookeeper", fields, tags)
 
 	return nil
+}
+
+// parseMntr parses the response of the "mntr" four-letter-word command into
+// fields and the reported server state. Each line has the form
+// "zk_<key>\t<value>". A tab cannot appear in a ZooKeeper znode name, so it is
+// a safe delimiter even when the key embeds a znode name containing otherwise
+// arbitrary characters (spaces, '%', ':', and so on). Lines that do not match
+// this form are skipped (logged at warning) so a single unparseable metric does
+// not drop the whole scrape.
+func (z *Zookeeper) parseMntr(r io.Reader) (map[string]interface{}, string) {
+	var zookeeperState string
+	fields := make(map[string]interface{})
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		key, value, found := strings.Cut(line, "\t")
+		if !found || !strings.HasPrefix(key, "zk_") {
+			z.Log.Warnf("Skipping unexpected line in mntr response: %q", line)
+			continue
+		}
+
+		measurement := strings.TrimPrefix(key, "zk_")
+		value = strings.TrimSpace(value)
+
+		if measurement == "server_state" {
+			zookeeperState = value
+			continue
+		}
+
+		// First attempt to parse as an int
+		iVal, err := strconv.ParseInt(value, 10, 64)
+		if err == nil {
+			fields[measurement] = iVal
+			continue
+		}
+
+		// If set, attempt to parse as a float
+		if z.ParseFloats == "float" {
+			fVal, err := strconv.ParseFloat(value, 64)
+			if err == nil {
+				fields[measurement] = fVal
+				continue
+			}
+		}
+
+		// Finally, save as a string
+		fields[measurement] = value
+	}
+
+	return fields, zookeeperState
 }
 
 func (z *Zookeeper) dial(ctx context.Context, addr string) (net.Conn, error) {

--- a/plugins/inputs/zookeeper/zookeeper_test.go
+++ b/plugins/inputs/zookeeper/zookeeper_test.go
@@ -2,6 +2,7 @@ package zookeeper
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +25,33 @@ func TestInit(t *testing.T) {
 	require.Equal(t, config.Duration(5*time.Second), plugin.Timeout)
 
 	require.Nil(t, plugin.tlsConfig)
+}
+
+func TestParseMntr(t *testing.T) {
+	mntr := strings.Join([]string{
+		"zk_version\t3.8.0",
+		"zk_server_state\tleader",
+		"zk_avg_latency\t1.5",
+		"zk_packets_received\t42",
+		// Per-namespace metric whose embedded znode name contains '%'.
+		"zk_avg_action_update_service_users_privileges%key%4b39c570825d4773%done_write_per_namespace\t86.0",
+		// znode names allow most characters, including spaces and ':'.
+		"zk_avg_latency_for_my namespace:1\t7",
+		// Unparseable lines (no tab / wrong prefix) must be skipped.
+		"this is not a metric line",
+		"not_zk_prefixed\t1",
+	}, "\n") + "\n"
+
+	plugin := &Zookeeper{ParseFloats: "float", Log: testutil.Logger{}}
+	fields, state := plugin.parseMntr(strings.NewReader(mntr))
+
+	require.Equal(t, "leader", state)
+	require.Equal(t, int64(42), fields["packets_received"])
+	require.InDelta(t, 1.5, fields["avg_latency"], 1e-9)
+	require.InDelta(t, 86.0, fields["avg_action_update_service_users_privileges%key%4b39c570825d4773%done_write_per_namespace"], 1e-9)
+	require.Equal(t, int64(7), fields["avg_latency_for_my namespace:1"])
+	require.NotContains(t, fields, "server_state")
+	require.NotContains(t, fields, "not_zk_prefixed")
 }
 
 func TestZookeeperGeneratesMetricsIntegration(t *testing.T) {


### PR DESCRIPTION
Also my previous swap metrics fix got lost at some point (switching to the master branch as the branch for this repo)